### PR TITLE
fix: Fixed use of reserved names in FDK tutorial files

### DIFF
--- a/ForceDependentKinematics/Downloads/DemoSimpleArm.any
+++ b/ForceDependentKinematics/Downloads/DemoSimpleArm.any
@@ -117,14 +117,14 @@ Main = {
     
     
     // Muscles
-    AnyMuscleModel MuscleModel = 
+    AnyMuscleModel MusMdl = 
     {
       F0 = 2000;
     };
     
     AnyMuscleViaPoint M1 = 
     {
-      AnyMuscleModel &model = .MuscleModel;
+      AnyMuscleModel &model = .MusMdl;
       AnyRefFrame &org = .UpperArm.Muscle1;
       AnyRefFrame &ins = .LowerArm.Muscle1;
       AnyDrawMuscle drw = {};    
@@ -132,7 +132,7 @@ Main = {
     
     AnyMuscleViaPoint M2 = 
     {
-      AnyMuscleModel &model = .MuscleModel;
+      AnyMuscleModel &model = .MusMdl;
       AnyRefFrame &org = .UpperArm.Muscle2;
       AnyRefFrame &ins = .LowerArm.Muscle2;
       AnyDrawMuscle drw = {};
@@ -140,7 +140,7 @@ Main = {
     
     AnyMuscleViaPoint M3 = 
     {
-      AnyMuscleModel &model = .MuscleModel;
+      AnyMuscleModel &model = .MusMdl;
       AnyRefFrame &org = .UpperArm.Muscle3;
       AnyRefFrame &ins = .LowerArm.Muscle3;
       AnyDrawMuscle drw = {};      

--- a/ForceDependentKinematics/Downloads/DemoSimpleKnee.any
+++ b/ForceDependentKinematics/Downloads/DemoSimpleKnee.any
@@ -98,7 +98,7 @@ Main = {
         
     // Muscle
     AnyMuscleShortestPath Quadriceps = {
-      AnyMuscleModel MuscleModel = {
+      AnyMuscleModel MusMdl = {
         F0 = 6000;
       };
       AnyRefFrame &org = .Thigh.Quadriceps;

--- a/ForceDependentKinematics/Downloads/DemoSimpleKnee2.any
+++ b/ForceDependentKinematics/Downloads/DemoSimpleKnee2.any
@@ -124,7 +124,7 @@ Main = {
         
     // Muscle
     AnyMuscleShortestPath Quadriceps = {
-      AnyMuscleModel MuscleModel = {
+      AnyMuscleModel MusMdl = {
         F0 = 6000;
       };
       AnyRefFrame &org = .Thigh.Quadriceps;

--- a/ForceDependentKinematics/Downloads/DemoSimpleKnee3.any
+++ b/ForceDependentKinematics/Downloads/DemoSimpleKnee3.any
@@ -124,7 +124,7 @@ Main = {
         
     // Muscle
     AnyMuscleShortestPath Quadriceps = {
-      AnyMuscleModel MuscleModel = {
+      AnyMuscleModel MusMdl = {
         F0 = 6000;
       };
       AnyRefFrame &org = .Thigh.Quadriceps;

--- a/ForceDependentKinematics/Downloads/DemoSimpleKnee4.any
+++ b/ForceDependentKinematics/Downloads/DemoSimpleKnee4.any
@@ -162,7 +162,7 @@ Main = {
     
     // Muscle
     AnyMuscleShortestPath Quadriceps = {
-      AnyMuscleModel MuscleModel = {
+      AnyMuscleModel MusMdl = {
         F0 = 6000;
       };
       AnyRefFrame &org = .Thigh.Quadriceps;


### PR DESCRIPTION
This fixes a problem with the files which could be downloaded in the FDK tutorial. 

The files used a muscle model named "MuscleModel", which is now a reserved word in that context. 