### PR TITLE
Add system for building hidden future tutorials

### DIFF
--- a/A_study_of_studies/index.md
+++ b/A_study_of_studies/index.md
@@ -12,11 +12,6 @@ objective of this tutorial is to explain the sequence of a typical study from
 its mechanical system information, to the initial conditions, kinematics to the
 inverse dynamic analysis.
 
-::::{if-builder:: html
-```{rubric} Tutorial content
-```
-::::
-
 ```{toctree}
 :maxdepth: 1
 

--- a/Introduction_to_mechanics/index.md
+++ b/Introduction_to_mechanics/index.md
@@ -1,0 +1,18 @@
+
+::: {rst-class} break
+:::
+
+
+# Introduction to mechanics in AnyBody
+
+
+The individual windows will be explained in greater detail in the
+following lessons:
+
+```{toctree}
+:maxdepth: 1
+
+Lesson1 <lesson1>
+
+```
+

--- a/Introduction_to_mechanics/lesson1.md
+++ b/Introduction_to_mechanics/lesson1.md
@@ -1,0 +1,10 @@
+::: {rst-class} break
+:::
+
+# Lesson 1: What is multibody dynamics
+
+hello world
+
+## Subsection 1
+
+hello again

--- a/Tutorials.md
+++ b/Tutorials.md
@@ -67,3 +67,7 @@ Interface_features/index
 Troubleshooting_anyscript/intro
 Validation_of_models/index
 ```
+
+
+
+

--- a/Tutorials_future.md
+++ b/Tutorials_future.md
@@ -1,0 +1,37 @@
+---
+sd_hide_title: true
+---
+:::::::::{if-builder} html
+
+# **Future Tutorials**
+
+
+```{rubric} Future tutorials
+:class: sd-fs-4
+```
+
+You can find the available tutorials in the sidebar. The tutorials are ordered in a suitable sequence for new users who are unfamiliar with AnyBody, but this sequence may not be optimal for you depending on your background and interests.
+
+
+{doc}`Introduction to mechanics </Introduction_to_mechanics/index>`
+: Shows the basics of AnyBody.
+
+
+:::::::::
+
+
+
+```{toctree}
+:caption: Future tutorials
+:includehidden: true
+:maxdepth: 2
+:hidden: true
+:titlesonly: true
+
+Introduction_to_mechanics/index
+
+```
+
+
+
+

--- a/conf.py
+++ b/conf.py
@@ -123,6 +123,10 @@ exclude_patterns = [
     ".pytest_cache",
 ]
 
+if not tags.has("future_tutorials"):
+    exclude_patterns.append("Tutorials_future.md")
+    exclude_patterns.append("Introduction_to_mechanics/*")
+
 
 # The name of the Pygments (syntax highlighting) style to use.
 highlight_language = "AnyScriptDoc"

--- a/index.md
+++ b/index.md
@@ -143,9 +143,10 @@ GettingStarted
 :maxdepth: 2
 :hidden:
 :titlesonly: True
+:glob:
 
 
-Tutorials
+Tutorials*
 about
 ```
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,6 +11,7 @@ clean = "rm -rf _build"
 linkcheck = {cmd="sphinx-build -M linkcheck . _build -q", depends-on = ["clean"]}
 build-pdf = {cmd="sphinx-build -M simplepdf . _build", depends-on = ["clean"]}
 build-html = "sphinx-build -M html . _build"
+build-html-future = "sphinx-build -M html . _build -t future_tutorials"
 build-html-all = "sphinx-build -M html . _build -a"
 html = {cmd= 'explorer .\_build\html\index.html', depends_on = ["build-html-all"]}
 pdf = {cmd= 'explorer .\_build\simplepdf\Agada-Documentation.pdf', depends_on = ["build-pdf"]}


### PR DESCRIPTION
This feature adds the option to build hidden future tutorials. 

Building sphinx with the "-t future_tutorials" tag will enable this. 

It can also be enable by running the pixi task

`pixi run build-html-future`